### PR TITLE
Add checks that outputs are writable & inputs exist if outputting to or reading from a directory

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -94,6 +94,11 @@ int main(int argc, char **argv) {
     OtuTable otu_table;
     otu_table.load_otu_file(bootstrap_options.otu_filename);
 
+    // If bootstrap_prefix contains a directory, check that it exists
+    if (bootstrap_options.bootstrap_prefix.find('/') != std::string::npos) {
+	directory_exists(bootstrap_options.bootstrap_prefix);
+    }
+
     // Generate bootstraps
     get_and_write_bootstraps(otu_table, bootstrap_options.bootstrap_number, bootstrap_options.bootstrap_prefix, bootstrap_options.threads, bootstrap_options.seed);
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 
+#include <dirent.h>
 
 std::vector<std::string> PERMITTED_OTU_HEADERS = {"#OTU ID", "#OTU_ID", "OTU ID", "OTU_ID", "OTU_id", "OTU id"};
 
@@ -161,4 +162,16 @@ float float_from_optarg(const char *optarg) {
         }
     }
     return std::atof(string_float.c_str());
+}
+
+void directory_exists(const std::string &optarg) {
+    std::string outfile_dir(optarg);
+    outfile_dir.erase(outfile_dir.rfind("/"), outfile_dir.size());
+    DIR* dir = opendir(outfile_dir.c_str());
+    if (dir) {
+	closedir(dir);
+    } else {
+	fprintf(stderr, "Directory does not seem to exist: %s/\n", outfile_dir.c_str());
+	exit(1);
+    }
 }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,6 +1,8 @@
 #include "common.h"
 
+#ifndef _WIN32 // dirent.h is not available on windows
 #include <dirent.h>
+#endif
 
 std::vector<std::string> PERMITTED_OTU_HEADERS = {"#OTU ID", "#OTU_ID", "OTU ID", "OTU_ID", "OTU_id", "OTU id"};
 
@@ -165,6 +167,7 @@ float float_from_optarg(const char *optarg) {
 }
 
 void directory_exists(const std::string &optarg) {
+#ifndef _WIN32 // implementation doesn't work on windows
     std::string outfile_dir(optarg);
     outfile_dir.erase(outfile_dir.rfind("/"), outfile_dir.size());
     DIR* dir = opendir(outfile_dir.c_str());
@@ -174,4 +177,5 @@ void directory_exists(const std::string &optarg) {
 	fprintf(stderr, "Directory does not seem to exist: %s/\n", outfile_dir.c_str());
 	exit(1);
     }
+#endif
 }

--- a/src/common.h
+++ b/src/common.h
@@ -49,5 +49,6 @@ int int_from_optarg(const char *optarg);
 // Convert character to float (for commandline argument parsing)
 float float_from_optarg(const char *optarg);
 
+void directory_exists(const std::string &optarg);
 
 #endif

--- a/src/fastspar.cpp
+++ b/src/fastspar.cpp
@@ -47,6 +47,14 @@ int main(int argc, char **argv) {
     FastSpar fastspar(&otu_table, fastspar_options.iterations, fastspar_options.exclude_iterations,
                       fastspar_options.threshold, fastspar_options.threads, fastspar_options.seed);
 
+    // Check that the output files are accessible if not in current directory
+    if (fastspar_options.correlation_filename.find('/') != std::string::npos) {
+	directory_exists(fastspar_options.correlation_filename);
+    }
+    if (fastspar_options.covariance_filename.find('/') != std::string::npos) {
+	directory_exists(fastspar_options.covariance_filename);
+    }
+
     // Run FastSpar iterations
     fprintf(stdout, "Running SparCC iterations\n");
     fastspar.infer_correlation_and_covariance();

--- a/src/pvalue.cpp
+++ b/src/pvalue.cpp
@@ -237,6 +237,11 @@ int main(int argc, char **argv) {
 	    exit(0);
     }
 
+    // Check that the output files are accessible if not in current directory
+    if (pval_options.out_filename.find('/') != std::string::npos) {
+	directory_exists(pval_options.out_filename);
+    }
+
     // Read in otu tables (used to calculate total possible permutations)
     printf("Reading in OTU count table\n");
     OtuTable otu_table;

--- a/src/pvalue.cpp
+++ b/src/pvalue.cpp
@@ -229,6 +229,11 @@ int main(int argc, char **argv) {
     // Get commandline arguments
     PvalOptions pval_options = get_commandline_arguments(argc, argv);
 
+    // Check that the input prefix is accessible if in a folder
+    if (pval_options.bootstrap_prefix.find('/') != std::string::npos) {
+	directory_exists(pval_options.bootstrap_prefix);
+    }
+
     // Collect bootstrap correlation file paths and then make sure we have found the correct number
     std::vector<std::string> bs_cor_paths = get_bootstrap_correlation_paths(pval_options.bootstrap_prefix);
     if (bs_cor_paths.size() != pval_options.permutations) {


### PR DESCRIPTION
Hi,

Thanks for creating fastspar, very useful and easy to use!

I was having some trouble with writing/reading from files that are in a directory different from where fastspar was run because the directory paths either didn't exist or had typos in them. I added a bunch of simple checks to deal with this. These checks do the following:
1. `fastspar` will now check if the output for --correlation or --covariance is in a directory (path contains a '/') and exit with an error message if the directory (path stripped of all characters after the last '/') doesn't exist or isn't accessible. Previously the program ran fine without errors but didn't produce any output.
2. `fastspar_bootstrap` will check if --prefix is in a directory and exit if that directory doesn't exist. Previously the program produced a segmentation fault if this was the case.
3. `fastspar_pvalues` checks performs the same check as 1. for --outfile, and the same check as 2. for --prefix. Previously errors in --outfile caused the program to run fine but produce output, and errors in --prefix resulted in a slightly misleading error message about not having the correct number files in the folder.

The checks for the directory use <dirent.h> which is not available on windows systems, so I wrapped the relevant code in a preprocessor directive which removes it when compiling on windows.